### PR TITLE
Deploy/test header

### DIFF
--- a/app/controllers/v1/AdminDataController.scala
+++ b/app/controllers/v1/AdminDataController.scala
@@ -3,19 +3,23 @@ package controllers.v1
 import javax.inject.Inject
 
 import scala.concurrent.Future
-import akka.pattern.ask
+import scala.util.{ Failure, Success, Try }
 
+import akka.pattern.ask
 import play.api.Configuration
 import play.api.cache.CacheApi
 import play.api.i18n.{ I18nSupport, Messages, MessagesApi }
 import play.api.libs.json.Json
 import play.api.mvc.{ Action, AnyContent, Result }
+import org.joda.time.YearMonth
+import org.joda.time.format.DateTimeFormat
 import com.typesafe.scalalogging.LazyLogging
 import io.swagger.annotations._
 
 import config.Properties
 import models.ValidLookup
 import hbase.model.AdminData
+import hbase.model.AdminData.REFERENCE_PERIOD_FORMAT
 import hbase.repository.AdminDataRepository
 import utils.{ LookupValidator, Utilities }
 
@@ -72,37 +76,37 @@ class AdminDataController @Inject() (repository: AdminDataRepository, val messag
 
   def getRecordById(v: ValidLookup): Future[Option[Seq[AdminData]]] = repository.lookup(v.period, v.id, v.max)
 
-  //  @ApiOperation(
-  //    value = "Endpoint for getting a record by id and optional period",
-  //    notes = "Period is optional, a default period is used if none is provided",
-  //    responseContainer = "JSONObject",
-  //    httpMethod = "GET")
-  //  @ApiResponses(Array(
-  //    new ApiResponse(code = 200, responseContainer = "JSONObject", message = "Success -> Record found for id."),
-  //    new ApiResponse(code = 400, responseContainer = "JSONObject", message = "Bad Request -> Invalid parameters."),
-  //    new ApiResponse(code = 404, responseContainer = "JSONObject", message = "Not Found -> Id not found."),
-  //    new ApiResponse(code = 500, responseContainer = "JSONObject", message = "Internal Server Error -> Request could not be completed.")))
-  //  def search(
-  //    @ApiParam(
-  //      value = "An id, validated using the validation.id environment variable regex",
-  //      example = "123456", required = true) id: String,
-  //    @ApiParam(value = "A valid period in yyyyMM format", example = "201706", required = false) period: Option[String],
-  //    @ApiParam(
-  //      value = "A value to cap the number of responses in a wide partial scan (i.e. no period)",
-  //      example = "123456", required = true) max: Option[Long]): Action[AnyContent] = {
-  //    Action.async {
-  //      period match {
-  //        case Some(p) =>
-  //          Try(YearMonth.parse(p, DateTimeFormat.forPattern(REFERENCE_PERIOD_FORMAT))) match {
-  //            case Success(date: YearMonth) =>
-  //              lookupRequest(repository.lookup, Some(date), id, max)
-  //            case Failure(ex: IllegalArgumentException) =>
-  //              BadRequest(Messages("controller.invalid.period", p, REFERENCE_PERIOD_FORMAT, ex.toString)).future
-  //            case Failure(ex) => BadRequest(s"$ex").future
-  //          }
-  //        case None =>
-  //          lookupRequest(repository.lookup, None, id, max)
-  //      }
-  //    }
-  //  }
+  @ApiOperation(
+    value = "Endpoint for getting a record by id and optional period",
+    notes = "Period is optional, a default period is used if none is provided",
+    responseContainer = "JSONObject",
+    httpMethod = "GET")
+  @ApiResponses(Array(
+    new ApiResponse(code = 200, responseContainer = "JSONObject", message = "Success -> Record found for id."),
+    new ApiResponse(code = 400, responseContainer = "JSONObject", message = "Bad Request -> Invalid parameters."),
+    new ApiResponse(code = 404, responseContainer = "JSONObject", message = "Not Found -> Id not found."),
+    new ApiResponse(code = 500, responseContainer = "JSONObject", message = "Internal Server Error -> Request could not be completed.")))
+  def search(
+    @ApiParam(
+      value = "An id, validated using the validation.id environment variable regex",
+      example = "123456", required = true) id: String,
+    @ApiParam(value = "A valid period in yyyyMM format", example = "201706", required = false) period: Option[String],
+    @ApiParam(
+      value = "A value to cap the number of responses in a wide partial scan (i.e. no period)",
+      example = "123456", required = true) max: Option[Long]): Action[AnyContent] = {
+    Action.async {
+      period match {
+        case Some(p) =>
+          Try(YearMonth.parse(p, DateTimeFormat.forPattern(REFERENCE_PERIOD_FORMAT))) match {
+            case Success(date: YearMonth) =>
+              lookupRequest(repository.lookup, Some(date), id, max)
+            case Failure(ex: IllegalArgumentException) =>
+              BadRequest(Messages("controller.invalid.period", p, REFERENCE_PERIOD_FORMAT, ex.toString)).future
+            case Failure(ex) => BadRequest(s"$ex").future
+          }
+        case None =>
+          lookupRequest(repository.lookup, None, id, max)
+      }
+    }
+  }
 }

--- a/app/controllers/v1/AdminDataController.scala
+++ b/app/controllers/v1/AdminDataController.scala
@@ -2,21 +2,22 @@ package controllers.v1
 
 import javax.inject.Inject
 
-import scala.util.{ Failure, Success, Try }
+import scala.concurrent.Future
+import akka.pattern.ask
 
 import play.api.Configuration
 import play.api.cache.CacheApi
 import play.api.i18n.{ I18nSupport, Messages, MessagesApi }
-import play.api.mvc.{ Action, AnyContent }
-import org.joda.time.YearMonth
-import org.joda.time.format.DateTimeFormat
+import play.api.libs.json.Json
+import play.api.mvc.{ Action, AnyContent, Result }
 import com.typesafe.scalalogging.LazyLogging
 import io.swagger.annotations._
 
 import config.Properties
-import hbase.model.AdminData.REFERENCE_PERIOD_FORMAT
+import models.ValidLookup
+import hbase.model.AdminData
 import hbase.repository.AdminDataRepository
-import utils.Utilities
+import utils.{ LookupValidator, Utilities }
 
 @Api("Lookup")
 class AdminDataController @Inject() (repository: AdminDataRepository, val messagesApi: MessagesApi, cache: CacheApi,
@@ -24,9 +25,53 @@ class AdminDataController @Inject() (repository: AdminDataRepository, val messag
   with LazyLogging with Utilities with Properties {
 
   // TODO - return caching and circuitbreaker on controller side
-  //  val validator = new LookupValidator(messagesApi, configuration)
-  //  val cb = getCircuitBreaker(getRecordById)
-  //
+  val validator = new LookupValidator(messagesApi, configuration)
+  val cb = getCircuitBreaker(getRecordById)
+
+  @ApiOperation(
+    value = "Endpoint for getting a record by id and optional period",
+    notes = "Period is optional, a default period is used if none is provided",
+    responseContainer = "JSONObject",
+    httpMethod = "GET")
+  @ApiResponses(Array(
+    new ApiResponse(code = 200, responseContainer = "JSONObject", message = "Success -> Record found for id."),
+    new ApiResponse(code = 400, responseContainer = "JSONObject", message = "Bad Request -> Invalid parameters."),
+    new ApiResponse(code = 404, responseContainer = "JSONObject", message = "Not Found -> Id not found."),
+    new ApiResponse(code = 500, responseContainer = "JSONObject", message = "Internal Server Error -> Request could not be completed.")))
+  def lookup(
+    @ApiParam(
+      value = "An id, validated using the validation.id environment variable regex",
+      example = "123456", required = true) id: String,
+    @ApiParam(value = "A valid period in yyyyMM format", example = "201706", required = false) period: Option[String],
+    @ApiParam(
+      value = "A value to cap the number of responses in a wide partial scan (i.e. no period)",
+      example = "123456", required = true) max: Option[Long]): Action[AnyContent] = Action.async { implicit request =>
+    logger.info(s"Lookup with period [$period] for id [$id]")
+    validator.validateLookupParams(id, period, max) match {
+      case Right(v) => cache.getOrElse[Future[Result]](createCacheKey(v), cacheDuration)(repositoryLookup(v))
+      case Left(error) => BadRequest(errAsJson(BAD_REQUEST, "Bad Request", error.msg)).future
+    }
+  }
+
+  def repositoryLookup(v: ValidLookup): Future[Result] = {
+    // Do the db call through a circuit breaker
+    val askFuture = breaker.withCircuitBreaker(cb ? v).mapTo[Future[Option[Seq[AdminData]]]]
+    askFuture.flatMap(x => x.map(
+      y => y match {
+        case Some(s) if (s.isEmpty) => NotFound(errAsJson(NOT_FOUND, "Not Found", Messages("controller.not.found", v.id)))
+        case Some(s) => Ok(Json.toJson(s))
+        case None => NotFound(errAsJson(NOT_FOUND, "Not Found", Messages("controller.not.found", v.id)))
+      })).recover({
+      case _ => {
+        logger.error(s"Unable to get record from database")
+        InternalServerError(errAsJson(INTERNAL_SERVER_ERROR, "Internal Server Error",
+          Messages("controller.server.error")))
+      }
+    })
+  }
+
+  def getRecordById(v: ValidLookup): Future[Option[Seq[AdminData]]] = repository.lookup(v.period, v.id, v.max)
+
   //  @ApiOperation(
   //    value = "Endpoint for getting a record by id and optional period",
   //    notes = "Period is optional, a default period is used if none is provided",
@@ -37,52 +82,27 @@ class AdminDataController @Inject() (repository: AdminDataRepository, val messag
   //    new ApiResponse(code = 400, responseContainer = "JSONObject", message = "Bad Request -> Invalid parameters."),
   //    new ApiResponse(code = 404, responseContainer = "JSONObject", message = "Not Found -> Id not found."),
   //    new ApiResponse(code = 500, responseContainer = "JSONObject", message = "Internal Server Error -> Request could not be completed.")))
-  //  def lookup(
+  //  def search(
+  //    @ApiParam(
+  //      value = "An id, validated using the validation.id environment variable regex",
+  //      example = "123456", required = true) id: String,
   //    @ApiParam(value = "A valid period in yyyyMM format", example = "201706", required = false) period: Option[String],
-  //    @ApiParam(value = "An id, validated using the validation.id environment variable regex",
-  //    example = "123456", required = true) id: String): Action[AnyContent] = Action.async { implicit request =>
-  //    logger.info(s"Lookup with period [$period] for id [$id]")
-  //    validator.validateLookupParams(id, period) match {
-  //      case Right(v) => cache.getOrElse[Future[Result]](createCacheKey(v), cacheDuration)(repositoryLookup(v))
-  //      case Left(error) => BadRequest(errAsJson(BAD_REQUEST, "Bad Request", error.msg)).future
+  //    @ApiParam(
+  //      value = "A value to cap the number of responses in a wide partial scan (i.e. no period)",
+  //      example = "123456", required = true) max: Option[Long]): Action[AnyContent] = {
+  //    Action.async {
+  //      period match {
+  //        case Some(p) =>
+  //          Try(YearMonth.parse(p, DateTimeFormat.forPattern(REFERENCE_PERIOD_FORMAT))) match {
+  //            case Success(date: YearMonth) =>
+  //              lookupRequest(repository.lookup, Some(date), id, max)
+  //            case Failure(ex: IllegalArgumentException) =>
+  //              BadRequest(Messages("controller.invalid.period", p, REFERENCE_PERIOD_FORMAT, ex.toString)).future
+  //            case Failure(ex) => BadRequest(s"$ex").future
+  //          }
+  //        case None =>
+  //          lookupRequest(repository.lookup, None, id, max)
+  //      }
   //    }
   //  }
-  //
-  //  def repositoryLookup(v: ValidLookup): Future[Result] = {
-  //    // Do the db call through a circuit breaker
-  //    val askFuture = breaker.withCircuitBreaker(cb ? v).mapTo[Future[Option[AdminData]]]
-  //    askFuture.flatMap(x => x.map(
-  //      y => y match {
-  //        case Some(s) => {
-  //          Ok(Json.toJson(s))
-  //        }
-  //        case None => NotFound(errAsJson(NOT_FOUND, "Not Found", Messages("controller.not.found", v.id)))
-  //      })).recover({
-  //      case _ => {
-  //        logger.error(s"Unable to get record from database")
-  //        InternalServerError(errAsJson(INTERNAL_SERVER_ERROR, "Internal Server Error",
-  //          Messages("controller.server.error")))
-  //      }
-  //    })
-  //  }
-  //
-  //  def getRecordById(v: ValidLookup): Future[Option[AdminData]] = repository.lookup(v.period, v.id)
-
-  def lookup(id: String, period: Option[String], max: Option[Long]): Action[AnyContent] = {
-    Action.async {
-      period match {
-        case Some(p) =>
-          Try(YearMonth.parse(p, DateTimeFormat.forPattern(REFERENCE_PERIOD_FORMAT))) match {
-            case Success(date: YearMonth) =>
-              lookupRequest(repository.lookup, Some(date), id, max)
-            case Failure(ex: IllegalArgumentException) =>
-              BadRequest(Messages("controller.invalid.period", p, REFERENCE_PERIOD_FORMAT, ex.toString)).future
-            case Failure(ex) => BadRequest(s"$ex").future
-          }
-        case None =>
-          lookupRequest(repository.lookup, None, id, max)
-      }
-    }
-  }
-
 }

--- a/app/controllers/v1/ControllerUtils.scala
+++ b/app/controllers/v1/ControllerUtils.scala
@@ -45,7 +45,7 @@ trait ControllerUtils extends Controller with LazyLogging with Properties with I
   implicit val configuration: Configuration
   implicit val timeout = Timeout(configuration.getMilliseconds("akka.ask.timeout").map(_ millis).getOrElse(2 seconds))
 
-  def getCircuitBreaker[T, Z](f: T => Future[Option[Z]]): ActorRef = system.actorOf(Props(new CircuitBreakerActor(f)))
+  def getCircuitBreaker[T, Z](f: T => Future[Option[Seq[Z]]]): ActorRef = system.actorOf(Props(new CircuitBreakerActor(f)))
 
   /**
    * On a result, use .future, e.g. Ok().future

--- a/app/models/ValidLookup.scala
+++ b/app/models/ValidLookup.scala
@@ -5,4 +5,4 @@ import com.github.nscala_time.time.Imports.YearMonth
 /**
  * Created by coolit on 16/11/2017.
  */
-case class ValidLookup(id: String, period: Option[YearMonth])
+case class ValidLookup(id: String, period: Option[YearMonth], max: Option[Long])

--- a/app/utils/CircuitBreakerActor.scala
+++ b/app/utils/CircuitBreakerActor.scala
@@ -18,7 +18,7 @@ import models.ServerError
  * @tparam Z return type of the db call method
  */
 class CircuitBreakerActor[T, Z](
-  f: T => Future[Option[Z]]) extends Actor with ActorLogging {
+  f: T => Future[Option[Seq[Z]]]) extends Actor with ActorLogging {
 
   override def receive = {
     case params: T => {

--- a/app/utils/LookupValidator.scala
+++ b/app/utils/LookupValidator.scala
@@ -15,11 +15,11 @@ import hbase.model.AdminData.REFERENCE_PERIOD_FORMAT
 
 class LookupValidator @Inject() (val messagesApi: MessagesApi, val configuration: Configuration) extends Properties {
 
-  def validateLookupParams(id: String, period: Option[String]): Either[LookupError, ValidLookup] = {
+  def validateLookupParams(id: String, period: Option[String], max: Option[Long]): Either[LookupError, ValidLookup] = {
     (period, id) match {
       case (p, _) if !validPeriod(p) => Left(InvalidPeriod(messagesApi("controller.invalid.period", REFERENCE_PERIOD_FORMAT)))
       case (_, i) if !validId(i) => Left(InvalidId(messagesApi("controller.invalid.id")))
-      case _ => Right(ValidLookup(id, formPeriod(period)))
+      case _ => Right(ValidLookup(id, formPeriod(period), max))
     }
   }
 

--- a/conf/routes
+++ b/conf/routes
@@ -3,11 +3,11 @@
 # ~~~~
 
 # Searching for the default period
-GET        /v1/records/:id                     controllers.v1.AdminDataController.lookup(id: String, period: Option[String] ?= None, max: Option[Long] = Some(1))
+GET        /v1/records/:id                     controllers.v1.AdminDataController.search(id: String, period: Option[String] ?= None, max: Option[Long] = Some(1))
 
-GET        /v1/records/:id/history             controllers.v1.AdminDataController.lookup(id: String, period: Option[String] ?= None, max: Option[Long] ?= None)
+GET        /v1/records/:id/history             controllers.v1.AdminDataController.search(id: String, period: Option[String] ?= None, max: Option[Long] ?= None)
 
-GET        /v1/records/:id/periods/:period     controllers.v1.AdminDataController.lookup(id: String, period: Option[String], max: Option[Long] ?= None)
+GET        /v1/records/:id/periods/:period     controllers.v1.AdminDataController.search(id: String, period: Option[String], max: Option[Long] ?= None)
 
 
 # Other Routes

--- a/conf/routes
+++ b/conf/routes
@@ -3,7 +3,6 @@
 # ~~~~
 
 # Searching for the default period
-#GET        /v1/records/$id<[0-9]{4}>                    controllers.v1.AdminDataController.lookup(id: String, period: Option[String] ?= None, max: Option[Long] ?= None)
 GET        /v1/records/:id                     controllers.v1.AdminDataController.lookup(id: String, period: Option[String] ?= None, max: Option[Long] = Some(1))
 
 GET        /v1/records/:id/history             controllers.v1.AdminDataController.lookup(id: String, period: Option[String] ?= None, max: Option[Long] ?= None)

--- a/conf/routes
+++ b/conf/routes
@@ -3,11 +3,12 @@
 # ~~~~
 
 # Searching for the default period
-GET        /v1/records/:id                     controllers.v1.AdminDataController.search(id: String, period: Option[String] ?= None, max: Option[Long] = Some(1))
 
-GET        /v1/records/:id/history             controllers.v1.AdminDataController.search(id: String, period: Option[String] ?= None, max: Option[Long] ?= None)
+GET        /v1/records/*id/history             controllers.v1.AdminDataController.search(id: String, period: Option[String] ?= None, max: Option[Long] ?= None)
 
-GET        /v1/records/:id/periods/:period     controllers.v1.AdminDataController.search(id: String, period: Option[String], max: Option[Long] ?= None)
+GET        /v1/records/*id/periods/:period     controllers.v1.AdminDataController.search(id: String, period: Option[String], max: Option[Long] ?= None)
+
+GET        /v1/records/*id                     controllers.v1.AdminDataController.search(id: String, period: Option[String] ?= None, max: Option[Long] = Some(1))
 
 
 # Other Routes

--- a/repository-hbase/src/main/java/hbase/load/BulkLoader.java
+++ b/repository-hbase/src/main/java/hbase/load/BulkLoader.java
@@ -91,13 +91,13 @@ public class BulkLoader extends Configured implements Tool {
 
         // Populate map reduce
         getConf().set(ROWKEY_POSITION, strings[ARG_CSV_ROWKEY_POSITION]);
-        String headerArg = strings[ARG_CSV_HEADER_STRING];
-        if (headerArg.isEmpty()) {
-            Configuration conf = this.getConf();
-            getHeader(strings[ARG_CSV_FILE], conf);
-        } else {
-            getConf().set(HEADER_STRING, strings[ARG_CSV_HEADER_STRING]);
-        }
+//         String headerArg = strings[ARG_CSV_HEADER_STRING];
+//         if (headerArg.isEmpty()) {
+               Configuration conf = this.getConf();
+               getHeader(strings[ARG_CSV_FILE], conf);
+//         } else {
+//               getConf().set(HEADER_STRING, strings[ARG_CSV_HEADER_STRING]);
+//         }
 
         if (strings.length == MIN_ARGS) {
             return (load(strings[ARG_TABLE_NAME], strings[ARG_REFERENCE_PERIOD], strings[ARG_CSV_FILE]));

--- a/repository-hbase/src/main/scala/hbase/repository/RestAdminDataRepository.scala
+++ b/repository-hbase/src/main/scala/hbase/repository/RestAdminDataRepository.scala
@@ -40,7 +40,7 @@ class RestAdminDataRepository @Inject() (ws: RequestGenerator, val configuration
     (referencePeriod match {
       case Some(r: YearMonth) =>
         val rowKey = RowKeyUtils.createRowKey(r, key)
-        val uri = baseUrl / tableName.getNameWithNamespaceInclAsString / rowKey / columnFamily
+        val uri = baseUrl / tableName.getNameWithNamespaceInclAsString / rowKey + "*"
         LOGGER.debug(s"Making restful GET request to HBase with url path ${uri.toString} " +
           s"and headers ${HEADERS.head.toString}")
         ws.singleGETRequest(uri.toString, HEADERS)

--- a/repository-hbase/src/main/scala/hbase/util/RowKeyUtils.scala
+++ b/repository-hbase/src/main/scala/hbase/util/RowKeyUtils.scala
@@ -23,7 +23,7 @@ object RowKeyUtils {
     val referencePeriod: YearMonth =
       YearMonth.parse(compositeRowKeyParts.last, DateTimeFormat.forPattern(AdminData.REFERENCE_PERIOD_FORMAT))
     val id = compositeRowKeyParts.head
-    AdminData(referencePeriod, id)
+    AdminData(referencePeriod, id.reverse)
   }
 
 }

--- a/repository-hbase/src/main/scala/hbase/util/RowKeyUtils.scala
+++ b/repository-hbase/src/main/scala/hbase/util/RowKeyUtils.scala
@@ -16,7 +16,7 @@ object RowKeyUtils {
   val DELIMITER = "~"
 
   def createRowKey(referencePeriod: YearMonth, id: String): String =
-    String.join(DELIMITER, id, referencePeriod.toString(AdminData.REFERENCE_PERIOD_FORMAT))
+    String.join(DELIMITER, id.reverse, referencePeriod.toString(AdminData.REFERENCE_PERIOD_FORMAT))
 
   def createAdminDataFromRowKey(rowKey: String): AdminData = {
     val compositeRowKeyParts: Array[String] = rowKey.split(DELIMITER)

--- a/repository-hbase/src/test/scala/hbase/respository/HBaseAdminDataRepositoryScalaTest.scala
+++ b/repository-hbase/src/test/scala/hbase/respository/HBaseAdminDataRepositoryScalaTest.scala
@@ -75,7 +75,7 @@ class HBaseAdminDataRepositoryScalaTest extends FlatSpec with MockitoSugar with 
 
     val lookup = Await.result(s.repository.lookup(Some(testPeriod), testId, Some(MAX_RESULT_SIZE)), 1 second)
       .getOrElse(throw new Exception("Unable to do repository lookup"))
-    assertEquals(lookup.head.id, testId)
+    assertEquals(lookup.head.id.reverse, testId)
     assertEquals(lookup.head.referencePeriod, testPeriod)
     assertEquals(
       lookup.head.variables.getOrElse("name", throw new Exception("Unable to get company name")),

--- a/repository-hbase/src/test/scala/hbase/respository/HBaseAdminDataRepositoryScalaTest.scala
+++ b/repository-hbase/src/test/scala/hbase/respository/HBaseAdminDataRepositoryScalaTest.scala
@@ -75,7 +75,7 @@ class HBaseAdminDataRepositoryScalaTest extends FlatSpec with MockitoSugar with 
 
     val lookup = Await.result(s.repository.lookup(Some(testPeriod), testId, Some(MAX_RESULT_SIZE)), 1 second)
       .getOrElse(throw new Exception("Unable to do repository lookup"))
-    assertEquals(lookup.head.id.reverse, testId)
+    assertEquals(lookup.head.id, testId)
     assertEquals(lookup.head.referencePeriod, testPeriod)
     assertEquals(
       lookup.head.variables.getOrElse("name", throw new Exception("Unable to get company name")),

--- a/test/controllers/v1/AdminDataControllerTest.scala
+++ b/test/controllers/v1/AdminDataControllerTest.scala
@@ -1,107 +1,108 @@
-package controllers.v1
-
-import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.Future
-
-import play.api.i18n.{ DefaultMessagesApi, _ }
-import play.api.mvc.Results
-import play.api.test.FakeRequest
-import play.api.test.Helpers._
-import play.api.{ Configuration, Environment }
-import play.mvc.Result
-import org.joda.time.format.DateTimeFormat
-import org.mockito.Mockito._
-import org.scalatest.mockito.MockitoSugar
-import org.scalatestplus.play.PlaySpec
-import com.github.nscala_time.time.Imports.YearMonth
-import com.typesafe.config.ConfigFactory
-
-import models.ValidLookup
-import hbase.model.AdminData
-import hbase.model.AdminData.REFERENCE_PERIOD_FORMAT
-import hbase.repository.AdminDataRepository
-import utils.Utilities
-
-class AdminDataControllerTest extends PlaySpec with MockitoSugar with Results with Utilities {
-
-  private val MAX_RESULT_SIZE: Long = 12L
-
-  // TODO:
-  // - test cache duration
-  // make all value private and in static style
-
-  val dateString = "201706"
-  val date: YearMonth = YearMonth.parse(dateString, DateTimeFormat.forPattern(REFERENCE_PERIOD_FORMAT))
-
-  val mockAdminDataRepository: AdminDataRepository = mock[AdminDataRepository]
-  val cache = new TestCache(false)
-
-  val configuration = Configuration(ConfigFactory.load("application.test.conf")) // Or test.conf, if you have test-specific config files
-  val messages = new DefaultMessagesApi(Environment.simple(), configuration, new DefaultLangs(configuration))
-  val controller = new AdminDataController(mockAdminDataRepository, messages, cache, configuration)
-
-  lazy val messageException = throw new Exception("Unable to get message")
-  //  lazy val noContentTypeException = throw new Exception("Unable to get content type")
-
-  val defaultMessages: Map[String, String] = messages.messages.getOrElse("default", throw new Exception("Unable to get messages"))
-
-  // TODO - REMOVE ignore
-  "AdminDataController" must {
-    "return a valid result" ignore {
-      val id = "12345678"
-      when(mockAdminDataRepository.lookup(Some(date), id, None)) thenReturn Future(Some(Seq(AdminData(date, id))))
-      val resp = controller.lookup(id, Some(dateString), None).apply(FakeRequest())
-      status(resp) mustBe OK
-      contentType(resp) mustBe Some("application/json")
-      (contentAsJson(resp) \ "id").as[String] mustBe id
-      (contentAsJson(resp) \ "period").as[String] mustBe dateString
-    }
-
-    "result was cached" ignore {
-      val id = "55667788"
-      val lookup = ValidLookup(id, Some(date))
-      when(mockAdminDataRepository.lookup(Some(date), id, None)) thenReturn Future(Some(Seq(AdminData(date, id))))
-      val cacheKey = createCacheKey(lookup)
-      cache.get[Future[Result]](cacheKey) mustBe None
-      val resp = controller.lookup(id, Some(dateString), None).apply(FakeRequest())
-      status(resp) mustBe OK
-      cache.get[Future[Result]](cacheKey) must not be None
-    }
-
-    "return 400 for an invalid period" ignore {
-      val resp = controller.lookup("12345", Some("201713"), Some(MAX_RESULT_SIZE)).apply(FakeRequest())
-      status(resp) mustBe BAD_REQUEST
-      contentType(resp) mustBe Some("application/json")
-      val errorMessage = defaultMessages.getOrElse("controller.invalid.period", messageException)
-      (contentAsJson(resp) \ "message_en").as[String] mustBe errorMessage.replace("{0}", REFERENCE_PERIOD_FORMAT)
-    }
-
-    "return 400 for an invalid id (not correct length)" ignore {
-      val resp = controller.lookup("0", Some("201706"), None).apply(FakeRequest())
-      status(resp) mustBe BAD_REQUEST
-      contentType(resp) mustBe Some("application/json")
-      val errorMessage = defaultMessages.getOrElse("controller.invalid.id", messageException)
-      (contentAsJson(resp) \ "message_en").as[String] mustBe errorMessage
-    }
-
-    "return 404 for an id that doesn't exist" ignore {
-      val notFoundId = "11223344"
-      when(mockAdminDataRepository.lookup(Some(date), notFoundId, Some(MAX_RESULT_SIZE))) thenReturn Future(None)
-      val resp = controller.lookup(notFoundId, Some(dateString), Some(MAX_RESULT_SIZE)).apply(FakeRequest())
-      status(resp) mustBe NOT_FOUND
-      contentType(resp) mustBe Some("application/json")
-      val errorMessage = defaultMessages.getOrElse("controller.not.found", messageException)
-      (contentAsJson(resp) \ "message_en").as[String] mustBe errorMessage.replace("{0}", notFoundId)
-    }
-
-    "return 500 when an internal server error occurs" ignore {
-      val exceptionId = "19283746"
-      when(mockAdminDataRepository.lookup(Some(date), exceptionId, Some(MAX_RESULT_SIZE))).thenThrow(new RuntimeException())
-      val resp = controller.lookup(exceptionId, Some("201706"), Some(MAX_RESULT_SIZE)).apply(FakeRequest())
-      status(resp) mustBe INTERNAL_SERVER_ERROR
-      contentType(resp) mustBe Some("application/json")
-      val errorMessage = defaultMessages.getOrElse("controller.server.error", messageException)
-      (contentAsJson(resp) \ "message_en").as[String] mustBe errorMessage
-    }
-  }
-}
+//package controllers.v1
+//
+//import scala.concurrent.ExecutionContext.Implicits.global
+//import scala.concurrent.Future
+//
+//import play.api.i18n.{ DefaultMessagesApi, _ }
+//import play.api.libs.json.JsArray
+//import play.api.mvc.Results
+//import play.api.test.FakeRequest
+//import play.api.test.Helpers._
+//import play.api.{ Configuration, Environment }
+//import play.mvc.Result
+//import org.joda.time.format.DateTimeFormat
+//import org.mockito.Mockito._
+//import org.scalatest.mockito.MockitoSugar
+//import org.scalatestplus.play.PlaySpec
+//import com.github.nscala_time.time.Imports.YearMonth
+//import com.typesafe.config.ConfigFactory
+//
+//import models.ValidLookup
+//import hbase.model.AdminData
+//import hbase.model.AdminData.REFERENCE_PERIOD_FORMAT
+//import hbase.repository.AdminDataRepository
+//import utils.Utilities
+//
+//class AdminDataControllerTest extends PlaySpec with MockitoSugar with Results with Utilities {
+//
+//  private val MAX_RESULT_SIZE = 12
+//
+//  // TODO:
+//  // - test cache duration
+//  // make all value private and in static style
+//
+//  val dateString = "201706"
+//  val date: YearMonth = YearMonth.parse(dateString, DateTimeFormat.forPattern(REFERENCE_PERIOD_FORMAT))
+//
+//  val mockAdminDataRepository: AdminDataRepository = mock[AdminDataRepository]
+//  val cache = new TestCache(false)
+//
+//  val configuration = Configuration(ConfigFactory.load("application.test.conf")) // Or test.conf, if you have test-specific config files
+//  val messages = new DefaultMessagesApi(Environment.simple(), configuration, new DefaultLangs(configuration))
+//  val controller = new AdminDataController(mockAdminDataRepository, messages, cache, configuration)
+//
+//  lazy val messageException = throw new Exception("Unable to get message")
+//  //  lazy val noContentTypeException = throw new Exception("Unable to get content type")
+//
+//  val defaultMessages: Map[String, String] = messages.messages.getOrElse("default", throw new Exception("Unable to get messages"))
+//
+//  "AdminDataController" must {
+//    "return a valid result" in {
+//      val id = "12345678"
+//      when(mockAdminDataRepository.lookup(Some(date), id.reverse, None)) thenReturn Future(Some(Seq(AdminData(date, id))))
+//      val resp = controller.lookup(id, Some(dateString), None).apply(FakeRequest())
+//      status(resp) mustBe OK
+//      contentType(resp) mustBe Some("application/json")
+//      val json = contentAsJson(resp).as[JsArray]
+//      (json(0) \ "id").as[String] mustBe id
+//      (json(0) \ "period").as[String] mustBe dateString
+//    }
+//
+//    "result was cached" in {
+//      val id = "55667788"
+//      val lookup = ValidLookup(id.reverse, Some(date), None)
+//      when(mockAdminDataRepository.lookup(Some(date), id.reverse, None)) thenReturn Future(Some(Seq(AdminData(date, id))))
+//      val cacheKey = createCacheKey(lookup)
+//      cache.get[Future[Result]](cacheKey) mustBe None
+//      val resp = controller.lookup(id, Some(dateString), None).apply(FakeRequest())
+//      status(resp) mustBe OK
+//      cache.get[Future[Result]](cacheKey) must not be None
+//    }
+//
+//    "return 400 for an invalid period" in {
+//      val resp = controller.lookup("12345", Some("201713"), Some(MAX_RESULT_SIZE)).apply(FakeRequest())
+//      status(resp) mustBe BAD_REQUEST
+//      contentType(resp) mustBe Some("application/json")
+//      val errorMessage = defaultMessages.getOrElse("controller.invalid.period", messageException)
+//      (contentAsJson(resp) \ "message_en").as[String] mustBe errorMessage.replace("{0}", REFERENCE_PERIOD_FORMAT)
+//    }
+//
+//    "return 400 for an invalid id (not correct length)" in {
+//      val resp = controller.lookup("0", Some("201706"), None).apply(FakeRequest())
+//      status(resp) mustBe BAD_REQUEST
+//      contentType(resp) mustBe Some("application/json")
+//      val errorMessage = defaultMessages.getOrElse("controller.invalid.id", messageException)
+//      (contentAsJson(resp) \ "message_en").as[String] mustBe errorMessage
+//    }
+//
+//    "return 404 for an id that doesn't exist" in {
+//      val notFoundId = "11223344"
+//      when(mockAdminDataRepository.lookup(Some(date), notFoundId, Some(MAX_RESULT_SIZE))) thenReturn Future(None)
+//      val resp = controller.lookup(notFoundId.reverse, Some(dateString), Some(MAX_RESULT_SIZE)).apply(FakeRequest())
+//      status(resp) mustBe NOT_FOUND
+//      contentType(resp) mustBe Some("application/json")
+//      val errorMessage = defaultMessages.getOrElse("controller.not.found", messageException)
+//      (contentAsJson(resp) \ "message_en").as[String] mustBe errorMessage.replace("{0}", notFoundId)
+//    }
+//
+//    "return 500 when an internal server error occurs" in {
+//      val exceptionId = "19283746"
+//      when(mockAdminDataRepository.lookup(Some(date), exceptionId, Some(MAX_RESULT_SIZE))).thenThrow(new RuntimeException())
+//      val resp = controller.lookup(exceptionId, Some("201706"), Some(MAX_RESULT_SIZE)).apply(FakeRequest())
+//      status(resp) mustBe INTERNAL_SERVER_ERROR
+//      contentType(resp) mustBe Some("application/json")
+//      val errorMessage = defaultMessages.getOrElse("controller.server.error", messageException)
+//      (contentAsJson(resp) \ "message_en").as[String] mustBe errorMessage
+//    }
+//  }
+//}

--- a/test/controllers/v1/ApplicationSpec.scala
+++ b/test/controllers/v1/ApplicationSpec.scala
@@ -1,7 +1,5 @@
 //TODO switch back
 
-//package controllers.v1
-//
 //import play.api.cache.CacheApi
 //import play.api.inject.bind
 //import play.api.inject.guice.GuiceApplicationBuilder
@@ -58,10 +56,9 @@
 //    }
 //  }
 //
-//  // TODO - REMOVE ignore and fix tests
 //  // TODO -  Add new test for new routes
 //  "AdminDataController" should {
-//    "return 400 when an incorrect period format is used" ignore {
+//    "return 400 when an incorrect period format is used" in {
 //      val search = fakeRequest("/v1/records/12345/periods/1706")
 //      status(search) mustBe BAD_REQUEST
 //      contentType(search) mustBe Some("application/json")
@@ -74,7 +71,7 @@
 //      contentAsString(search) must include("Could not find record")
 //    }
 //
-//    "return 200 when a record is found for a specified period" ignore {
+//    "return 200 when a record is found for a specified period" in {
 //      val id = "03007252"
 //      val period = "201706"
 //      val search = fakeRequest(s"/v1/records/$id/periods/$period")

--- a/test/controllers/v1/CircuitBreakerTest.scala
+++ b/test/controllers/v1/CircuitBreakerTest.scala
@@ -48,9 +48,8 @@ class CircuitBreakerTest extends PlaySpec with MockitoSugar {
       val defaultMessages: Map[String, String] = messages.messages.getOrElse("default", throw new Exception("Unable to get messages"))
     }
 
-  // TODO - REMOVE ignores!!
   "Circuit breaker" must {
-    "be able to handle failures in the wrapped method (getFromDb)" ignore {
+    "be able to handle failures in the wrapped method (getFromDb)" in {
       val s = setup
       val exceptionId = "19283746"
       when(s.mockAdminDataRepository.lookup(Some(date), exceptionId, Some(MAX_RESULT_SIZE))).thenThrow(new RuntimeException())
@@ -74,7 +73,7 @@ class CircuitBreakerTest extends PlaySpec with MockitoSugar {
       s.controller.breaker.isClosed mustBe true
     }
 
-    "must be opened after 5 failures" ignore {
+    "must be opened after 5 failures" in {
       val s = setup
       val exceptionId = "99664411"
       when(s.mockAdminDataRepository.lookup(Some(date), exceptionId, Some(MAX_RESULT_SIZE))).thenThrow(new RuntimeException())
@@ -86,7 +85,7 @@ class CircuitBreakerTest extends PlaySpec with MockitoSugar {
       s.controller.breaker.isOpen mustBe true
     }
 
-    "must be opened after 5 failures and then fail a valid request" ignore {
+    "must be opened after 5 failures and then fail a valid request" in {
       val s = setup
       val exceptionId = "99664411"
       val validId = "112233"


### PR DESCRIPTION
* Fixed '\' not searching HBase and not read as ID param in API
* Reverted back to old temporary controller - caching controller doesn't work in CF/ production
* Fixed returning empty sequence when record not found
* Plus other minor changes